### PR TITLE
Bind frontend delete to backend + delete modal + go back modal

### DIFF
--- a/LiveMapDashboard.Web/Controllers/PoiController.cs
+++ b/LiveMapDashboard.Web/Controllers/PoiController.cs
@@ -29,7 +29,7 @@ namespace LiveMapDashboard.Web.Controllers
 
             if (result.IsSuccess)
             {
-                ViewData["SuccessMessage"] = "Your request was successfully processed!";
+                ViewData["SuccessMessage"] = "The point of interest and its contents where successfully deleted!";
                 return View("index", await provider.Provide());
             }
             

--- a/LiveMapDashboard.Web/Controllers/PoiController.cs
+++ b/LiveMapDashboard.Web/Controllers/PoiController.cs
@@ -17,6 +17,33 @@ namespace LiveMapDashboard.Web.Controllers
             return View(viewModel);
         }
 
+        [HttpPost("delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Delete(
+            [FromServices] IPointOfInterestService service,
+            [FromServices] IViewModelProvider<PoiCrudformViewModel> provider,
+            PoiCrudformViewModel viewModel)
+        {
+            var poi = viewModel.ToDomainPointOfInterest();
+            var result = await service.Delete(poi.Id);
+
+            if (result.IsSuccess)
+            {
+                ViewData["SuccessMessage"] = "Your request was successfully processed!";
+                return View("index", await provider.Provide());
+            }
+            
+            ViewData["ErrorMessage"] = result.StatusCode switch
+            {
+                HttpStatusCode.BadRequest => "The submitted data was invalid. Please check the data you submitted.",
+                HttpStatusCode.Unauthorized => "You are not authorized to perform this action.",
+                HttpStatusCode.ServiceUnavailable => "The application unavailable. Please try again later.",
+                _ => "Something went wrong while trying to contact the application. Please try again later"
+            };
+            
+            return View("index", await provider.Hydrate(viewModel));
+        }
+
         [HttpPost]
         [Route("")]
         [ValidateAntiForgeryToken]

--- a/LiveMapDashboard.Web/Extensions/Mappers/ViewModelMapperExtensions.cs
+++ b/LiveMapDashboard.Web/Extensions/Mappers/ViewModelMapperExtensions.cs
@@ -42,12 +42,14 @@ public static class ViewModelMapperExtensions
     {
         return new()
         {
+            Id = viewModel.Id is not null 
+                ? Guid.Parse(viewModel.Id) 
+                : Guid.Empty,
             Title = viewModel.Title,
             Category = null!,
             CategoryName = viewModel.Category,
             Coordinate = viewModel.Coordinate,
             Description = viewModel.Description,
-            Id = Guid.Empty,
             Map = null!,
             MapId = Guid.Parse(viewModel.MapId),
             OpeningHours = viewModel.OpeningHours.ToDomainOpeningHoursList(),

--- a/LiveMapDashboard.Web/Models/Poi/PoiCrudformViewModel.cs
+++ b/LiveMapDashboard.Web/Models/Poi/PoiCrudformViewModel.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 namespace LiveMapDashboard.Web.Models.Poi;
 
 public sealed record PoiCrudformViewModel(
+    string? Id,
     string Title, 
     string Category, 
     string Description, 
@@ -18,6 +19,7 @@ public sealed record PoiCrudformViewModel(
 {
     public static PoiCrudformViewModel Empty => 
         new PoiCrudformViewModel(
+            Id: string.Empty,
             Title: string.Empty,
             Category: string.Empty,
             Description: string.Empty,

--- a/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/Default.cshtml
+++ b/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/Default.cshtml
@@ -3,37 +3,33 @@
 
 <div class="max-w-10xl pt-2 px-4 sm:px-6 lg:px-6 lg:pt-2 mx-auto">
     <div class="flex justify-between">
-        <a href="javascript:history.back()"
-           class="bg-transparent hover:bg-transparent px-4 py-2 text-blue-500 hover:bg-blue-600">
-            Go Back
-        </a>
-        <form method="post" asp-controller="poi" asp-action="Delete">
-            @Html.AntiForgeryToken()
-            <input type="hidden" asp-for="Id" value="d2351a07-7c59-64fc-467a-000748f91a2b"/>
-            
-            <button type="submit"
-                    class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600">
-                Delete
-            </button>
-        </form>
+        @await Html.PartialAsync("~/Views/Shared/Components/PoiForm/_GoBack.cshtml")
+
+        @if (Model.Id != string.Empty)
+        {
+            @await Html.PartialAsync("~/Views/Shared/Components/PoiForm/_Delete.cshtml", Model)
+        }
     </div>
 </div>
 
-<div class="max-w-10xl px-4 pb-10 sm:px-6 lg:px-6 lg:pb-14 mx-auto">
-    @if (ViewData["SuccessMessage"] != null)
-    {
-    <div class="mt-2 bg-teal-100 border border-teal-200 text-sm text-teal-800 rounded-lg p-4 dark:bg-teal-800/10 dark:border-teal-900 dark:text-teal-500" role="alert" tabindex="-1" aria-labelledby="hs-soft-color-success-label">
-        @ViewData["SuccessMessage"]
-    </div>
-    }
+@if (ViewData["SuccessMessage"] != null || ViewData["ErrorMessage"] != null)
+{
+    <div class="max-w-10xl px-4 pb-10 sm:px-6 lg:px-6 lg:pb-14 mx-auto">
+        @if (ViewData["SuccessMessage"] != null)
+        {
+            <div class="mt-2 bg-teal-100 border border-teal-200 text-sm text-teal-800 rounded-lg p-4 dark:bg-teal-800/10 dark:border-teal-900 dark:text-teal-500" role="alert" tabindex="-1" aria-labelledby="hs-soft-color-success-label">
+                @ViewData["SuccessMessage"]
+            </div>
+        }
 
-    @if (ViewData["ErrorMessage"] != null)
-    {
-    <div class="mt-2 bg-red-100 border border-red-200 text-sm text-red-800 rounded-lg p-4 dark:bg-red-800/10 dark:border-red-900 dark:text-red-500" role="alert" tabindex="-1" aria-labelledby="hs-soft-color-danger-label">
-        @ViewData["ErrorMessage"]
+        @if (ViewData["ErrorMessage"] != null)
+        {
+            <div class="mt-2 bg-red-100 border border-red-200 text-sm text-red-800 rounded-lg p-4 dark:bg-red-800/10 dark:border-red-900 dark:text-red-500" role="alert" tabindex="-1" aria-labelledby="hs-soft-color-danger-label">
+                @ViewData["ErrorMessage"]
+            </div>
+        }
     </div>
-    }
-</div>
+}
 
 <div class="max-w-10xl px-4 pb-10 sm:px-6 lg:px-6 lg:pb-14 mx-auto">
     <form method="post" asp-controller="poi" asp-action="submit">
@@ -55,7 +51,7 @@
         </div>
         
         <div class="mt-2 py-4 relative z-10">
-            <div class="flex justify-end gap-3 w-100">
+            <div class="flex justify-end gap-3 w-full">
                 <div class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600" onclick="confirmLeave()">
                     Cancel
                 </div>
@@ -67,11 +63,3 @@
         </div>
     </form>
 </div>
-
-<script>
-function confirmLeave() {
-    if (confirm("Are you sure you want to leave this page?")) {
-        window.location.href = "javascript:history.back()";
-    }
-}
-</script>

--- a/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/Default.cshtml
+++ b/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/Default.cshtml
@@ -7,8 +7,10 @@
            class="bg-transparent hover:bg-transparent px-4 py-2 text-blue-500 hover:bg-blue-600">
             Go Back
         </a>
-        <form method="delete" asp-controller="poi" asp-action="delete">
+        <form method="post" asp-controller="poi" asp-action="Delete">
             @Html.AntiForgeryToken()
+            <input type="hidden" asp-for="Id" value="d2351a07-7c59-64fc-467a-000748f91a2b"/>
+            
             <button type="submit"
                     class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600">
                 Delete

--- a/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/_Delete.cshtml
+++ b/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/_Delete.cshtml
@@ -1,0 +1,54 @@
+﻿@using LiveMapDashboard.Web.Models.Poi
+@model LiveMapDashboard.Web.Models.Poi.PoiCrudformViewModel
+
+<div class="text-center">
+    <button type="button" class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600 cursor-pointer" aria-haspopup="dialog" aria-expanded="false" aria-controls="delete-alert" data-hs-overlay="#delete-alert">
+        Delete
+    </button>
+</div>
+
+<div id="delete-alert" class="hs-overlay hidden size-full fixed top-0 start-0 z-80 overflow-x-hidden overflow-y-auto" role="dialog" tabindex="-1" aria-labelledby="delete-alert-label">
+    <div class="hs-overlay-open:mt-7 hs-overlay-open:opacity-100 hs-overlay-open:duration-500 mt-0 opacity-0 ease-out transition-all md:max-w-2xl md:w-full m-3 md:mx-auto">
+        <div class="relative flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl overflow-hidden dark:bg-neutral-900 dark:border-neutral-800">
+            <div class="absolute top-2 end-2">
+                <button type="button" class="size-8 inline-flex justify-center items-center gap-x-2 rounded-full border border-transparent bg-gray-100 text-gray-800 hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:text-neutral-400 dark:focus:bg-neutral-600" aria-label="Close" data-hs-overlay="#delete-alert">
+                    <span class="sr-only">Close</span>
+                    <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                </button>
+            </div>
+
+            <div class="p-4 sm:p-10 overflow-y-auto">
+                <div class="flex gap-x-4 md:gap-x-7">
+                    <span class="shrink-0 inline-flex justify-center items-center size-11 sm:w-15.5 sm:h-15.5 rounded-full border-4 border-red-50 bg-red-100 text-red-500 dark:bg-red-700 dark:border-red-600 dark:text-red-100">
+                        <svg class="shrink-0 size-5" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                          <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+                        </svg>
+                    </span>
+
+                    <div class="grow">
+                        <h3 id="delete-alert-label" class="mb-2 text-xl font-bold text-gray-800 dark:text-neutral-200">
+                            Delete Point Of Interest
+                        </h3>
+                        <p class="text-gray-500 dark:text-neutral-500">
+                            Permanently remove the point of interest and all of its contents from the map. This action is not reversible, so please continue with caution.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <form method="post" asp-controller="poi" asp-action="Delete">
+                @Html.AntiForgeryToken()
+                <input type="hidden" asp-for="Id"/>
+
+                <div class="flex justify-end items-center gap-x-2 py-3 px-4 bg-gray-50 border-t border-gray-200 dark:bg-neutral-950 dark:border-neutral-800">
+                    <button type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-50 dark:bg-transparent dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800" data-hs-overlay="#delete-alert">
+                        Cancel
+                    </button>
+                    <button type="submit" class="py-2 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-transparent bg-red-500 text-white hover:bg-red-600 disabled:opacity-50 disabled:pointer-events-none">
+                        Delete point of interest
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/_GoBack.cshtml
+++ b/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/_GoBack.cshtml
@@ -1,0 +1,46 @@
+﻿<div class="text-center">
+    <button type="button" class="bg-transparent hover:bg-transparent py-2 text-blue-500 hover:bg-blue-600 flex justify-center items-center cursor-pointer" aria-haspopup="dialog" aria-expanded="false" aria-controls="go-back-alert" data-hs-overlay="#go-back-alert">
+        <span class="inline-flex justify-center items-center size-11 rounded-full text-blue-600 dark:text-blue-500">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-left-icon lucide-arrow-left shrink-0 size-5"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
+        </span>
+        
+        Go back
+    </button>
+</div>
+
+<div id="go-back-alert" class="hs-overlay hidden size-full fixed top-0 start-0 z-80 overflow-x-hidden overflow-y-auto" role="dialog" tabindex="-1" aria-labelledby="go-back-alert-label">
+    <div class="hs-overlay-open:mt-7 hs-overlay-open:opacity-100 hs-overlay-open:duration-500 mt-0 opacity-0 ease-out transition-all sm:max-w-lg sm:w-full m-3 sm:mx-auto">
+        <div class="relative flex flex-col bg-white shadow-lg rounded-xl dark:bg-neutral-900">
+            <div class="absolute top-2 end-2">
+                <button type="button" class="size-8 inline-flex justify-center items-center gap-x-2 rounded-full border border-transparent bg-gray-100 text-gray-800 hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:text-neutral-400 dark:focus:bg-neutral-600" aria-label="Close" data-hs-overlay="#go-back-alert">
+                    <span class="sr-only">Close</span>
+                    <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                </button>
+            </div>
+
+            <div class="p-4 sm:p-10 text-center overflow-y-auto">
+                <span class="mb-4 inline-flex justify-center items-center size-15.5 rounded-full border-4 border-yellow-50 bg-yellow-100 text-yellow-500 dark:bg-yellow-700 dark:border-yellow-600 dark:text-yellow-100">
+                  <svg class="shrink-0 size-5" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                    <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+                  </svg>
+                </span>
+
+                <h3 id="go-back-alert-label" class="mb-2 text-2xl font-bold text-gray-800 dark:text-neutral-200">
+                    Leave changes
+                </h3>
+                <p class="text-gray-500 dark:text-neutral-500">
+                    Are you sure you would like to abandon your changes?
+                </p>
+
+                <div class="mt-6 flex justify-center gap-x-4">
+                    <a href="javascript:history.back()" class="py-2 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-50 dark:bg-transparent dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800">
+                        Leave changes
+                    </a>
+                    <button type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-transparent bg-blue-600 text-white hover:bg-blue-700 focus:outline-hidden focus:bg-blue-700 disabled:opacity-50 disabled:pointer-events-none" data-hs-overlay="#go-back-alert">
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/_Map.cshtml
+++ b/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/_Map.cshtml
@@ -1,7 +1,7 @@
 ﻿@using LiveMapDashboard.Web.Models.Poi
 @model LiveMapDashboard.Web.Models.Poi.PoiCrudformViewModel
 
-<div class="mt-2">
+<div>
     <script src="~/js/park-place-markers-maplibre.js" asp-append-version="true" type="module"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js"></script>
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="https://www.unpkg.com/@@mapbox/mapbox-gl-draw@1.5.0/dist/mapbox-gl-draw.css" />
 
     <!-- Kaart -->
-    <div class="card w-full h-full z-10 bg-white border border-gray-200 dark:bg-neutral-900 dark:border-neutral-700">
+    <div class="card w-full z-10 bg-white border border-gray-200 dark:bg-neutral-900 dark:border-neutral-700 rounded-lg">
         <div class="card-body w-full h-full">
             <div id="map" class="h-[50vh] w-full rounded-lg"></div>
         </div>

--- a/LiveMapDashboard.Web/wwwroot/css/styles.css
+++ b/LiveMapDashboard.Web/wwwroot/css/styles.css
@@ -7,13 +7,20 @@
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
+    --color-red-50: oklch(97.1% 0.013 17.38);
     --color-red-100: oklch(93.6% 0.032 17.717);
     --color-red-200: oklch(88.5% 0.062 18.334);
     --color-red-400: oklch(70.4% 0.191 22.216);
     --color-red-500: oklch(63.7% 0.237 25.331);
     --color-red-600: oklch(57.7% 0.245 27.325);
+    --color-red-700: oklch(50.5% 0.213 27.518);
     --color-red-800: oklch(44.4% 0.177 26.899);
     --color-red-900: oklch(39.6% 0.141 25.723);
+    --color-yellow-50: oklch(98.7% 0.026 102.212);
+    --color-yellow-100: oklch(97.3% 0.071 103.193);
+    --color-yellow-500: oklch(79.5% 0.184 86.047);
+    --color-yellow-600: oklch(68.1% 0.162 75.834);
+    --color-yellow-700: oklch(55.4% 0.135 66.442);
     --color-green-600: oklch(62.7% 0.194 149.214);
     --color-teal-100: oklch(95.3% 0.051 180.801);
     --color-teal-200: oklch(91% 0.096 180.426);
@@ -43,10 +50,12 @@
     --color-neutral-700: oklch(37.1% 0 0);
     --color-neutral-800: oklch(26.9% 0 0);
     --color-neutral-900: oklch(20.5% 0 0);
+    --color-neutral-950: oklch(14.5% 0 0);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
     --container-lg: 32rem;
+    --container-2xl: 42rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
@@ -55,6 +64,8 @@
     --text-lg--line-height: calc(1.75 / 1.125);
     --text-xl: 1.25rem;
     --text-xl--line-height: calc(1.75 / 1.25);
+    --text-2xl: 1.5rem;
+    --text-2xl--line-height: calc(2 / 1.5);
     --text-4xl: 2.25rem;
     --text-4xl--line-height: calc(2.5 / 2.25);
     --font-weight-medium: 500;
@@ -565,6 +576,9 @@
   .mt-5 {
     margin-top: calc(var(--spacing) * 5);
   }
+  .mt-6 {
+    margin-top: calc(var(--spacing) * 6);
+  }
   .mt-auto {
     margin-top: auto;
   }
@@ -657,6 +671,14 @@
   .size-8 {
     width: calc(var(--spacing) * 8);
     height: calc(var(--spacing) * 8);
+  }
+  .size-11 {
+    width: calc(var(--spacing) * 11);
+    height: calc(var(--spacing) * 11);
+  }
+  .size-15\.5 {
+    width: calc(var(--spacing) * 15.5);
+    height: calc(var(--spacing) * 15.5);
   }
   .size-full {
     width: 100%;
@@ -900,6 +922,9 @@
   .gap-x-3 {
     column-gap: calc(var(--spacing) * 3);
   }
+  .gap-x-4 {
+    column-gap: calc(var(--spacing) * 4);
+  }
   .space-x-3 {
     :where(& > :not(:last-child)) {
       --tw-space-x-reverse: 0;
@@ -1039,6 +1064,9 @@
   .border-gray-300 {
     border-color: var(--color-gray-300);
   }
+  .border-red-50 {
+    border-color: var(--color-red-50);
+  }
   .border-red-200 {
     border-color: var(--color-red-200);
   }
@@ -1050,6 +1078,9 @@
   }
   .border-white {
     border-color: var(--color-white);
+  }
+  .border-yellow-50 {
+    border-color: var(--color-yellow-50);
   }
   .border-t-transparent {
     border-top-color: transparent;
@@ -1101,6 +1132,9 @@
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-white) 10%, transparent);
     }
+  }
+  .bg-yellow-100 {
+    background-color: var(--color-yellow-100);
   }
   .fill-black {
     fill: var(--color-black);
@@ -1279,6 +1313,10 @@
   .align-top {
     vertical-align: top;
   }
+  .text-2xl {
+    font-size: var(--text-2xl);
+    line-height: var(--tw-leading, var(--text-2xl--line-height));
+  }
   .text-4xl {
     font-size: var(--text-4xl);
     line-height: var(--tw-leading, var(--text-4xl--line-height));
@@ -1358,6 +1396,9 @@
   }
   .text-white {
     color: var(--color-white);
+  }
+  .text-yellow-500 {
+    color: var(--color-yellow-500);
   }
   .capitalize {
     text-transform: capitalize;
@@ -1723,6 +1764,16 @@
       display: flex;
     }
   }
+  .sm\:h-15\.5 {
+    @media (width >= 40rem) {
+      height: calc(var(--spacing) * 15.5);
+    }
+  }
+  .sm\:w-15\.5 {
+    @media (width >= 40rem) {
+      width: calc(var(--spacing) * 15.5);
+    }
+  }
   .sm\:w-full {
     @media (width >= 40rem) {
       width: 100%;
@@ -1758,6 +1809,11 @@
       justify-content: flex-start;
     }
   }
+  .sm\:p-10 {
+    @media (width >= 40rem) {
+      padding: calc(var(--spacing) * 10);
+    }
+  }
   .sm\:px-6 {
     @media (width >= 40rem) {
       padding-inline: calc(var(--spacing) * 6);
@@ -1789,9 +1845,29 @@
       line-height: var(--tw-leading, var(--text-sm--line-height));
     }
   }
+  .md\:mx-auto {
+    @media (width >= 48rem) {
+      margin-inline: auto;
+    }
+  }
+  .md\:w-full {
+    @media (width >= 48rem) {
+      width: 100%;
+    }
+  }
+  .md\:max-w-2xl {
+    @media (width >= 48rem) {
+      max-width: var(--container-2xl);
+    }
+  }
   .md\:grid-cols-2 {
     @media (width >= 48rem) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .md\:gap-x-7 {
+    @media (width >= 48rem) {
+      column-gap: calc(var(--spacing) * 7);
     }
   }
   .md\:p-7 {
@@ -1836,6 +1912,16 @@
       border-color: var(--color-neutral-700);
     }
   }
+  .dark\:border-neutral-800 {
+    &:where(.dark, .dark *) {
+      border-color: var(--color-neutral-800);
+    }
+  }
+  .dark\:border-red-600 {
+    &:where(.dark, .dark *) {
+      border-color: var(--color-red-600);
+    }
+  }
   .dark\:border-red-900 {
     &:where(.dark, .dark *) {
       border-color: var(--color-red-900);
@@ -1844,6 +1930,11 @@
   .dark\:border-teal-900 {
     &:where(.dark, .dark *) {
       border-color: var(--color-teal-900);
+    }
+  }
+  .dark\:border-yellow-600 {
+    &:where(.dark, .dark *) {
+      border-color: var(--color-yellow-600);
     }
   }
   .dark\:bg-blue-500 {
@@ -1879,6 +1970,16 @@
       }
     }
   }
+  .dark\:bg-neutral-950 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-neutral-950);
+    }
+  }
+  .dark\:bg-red-700 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-red-700);
+    }
+  }
   .dark\:bg-red-800\/10 {
     &:where(.dark, .dark *) {
       background-color: color-mix(in srgb, oklch(44.4% 0.177 26.899) 10%, transparent);
@@ -1893,6 +1994,16 @@
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--color-teal-800) 10%, transparent);
       }
+    }
+  }
+  .dark\:bg-transparent {
+    &:where(.dark, .dark *) {
+      background-color: transparent;
+    }
+  }
+  .dark\:bg-yellow-700 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-yellow-700);
     }
   }
   .dark\:fill-neutral-200 {
@@ -1910,6 +2021,11 @@
       color: var(--color-neutral-200);
     }
   }
+  .dark\:text-neutral-300 {
+    &:where(.dark, .dark *) {
+      color: var(--color-neutral-300);
+    }
+  }
   .dark\:text-neutral-400 {
     &:where(.dark, .dark *) {
       color: var(--color-neutral-400);
@@ -1918,6 +2034,11 @@
   .dark\:text-neutral-500 {
     &:where(.dark, .dark *) {
       color: var(--color-neutral-500);
+    }
+  }
+  .dark\:text-red-100 {
+    &:where(.dark, .dark *) {
+      color: var(--color-red-100);
     }
   }
   .dark\:text-red-500 {
@@ -1933,6 +2054,11 @@
   .dark\:text-white {
     &:where(.dark, .dark *) {
       color: var(--color-white);
+    }
+  }
+  .dark\:text-yellow-100 {
+    &:where(.dark, .dark *) {
+      color: var(--color-yellow-100);
     }
   }
   .dark\:placeholder-neutral-500 {
@@ -2105,6 +2231,14 @@
       &:focus {
         --tw-ring-color: var(--color-neutral-600);
       }
+    }
+  }
+  .hs-overlay-open\:mt-7 {
+    &.open {
+      margin-top: calc(var(--spacing) * 7);
+    }
+    .open & {
+      margin-top: calc(var(--spacing) * 7);
     }
   }
   .hs-overlay-open\:opacity-100 {


### PR DESCRIPTION
> [!IMPORTANT]
> I wrote this based on the PR for #60 where the update was made for the POI's as i need a proper conversion and the ID in order to delete. Some methods and contents are missing so if you were to test it without small changes it wont work. You need to add small changes locally if you want to test it fully as we don't have a POI yet.

1. in the POIcontroller change the `poi` and `result` to this: 
```csharp 
// We dont have a full POI that can convert so we just parse the ID with this
var id = viewModel.Id is not null
                ? Guid.Parse(viewModel.Id)
                : Guid.Empty;
var result = await service.Delete(id);
```
2. pick a random ID in poi's and set that ID in the `id` field in `_Delete.cshtml` and set the if for poi.Id in `_Default.cshtml` to true to simulate we an "id"

I know this is not we want to do in a PR but I don't want to pull that branch in the feature unless its merged. When this merges back, and the PR #60 is approved I'll pull it to the feature to fully test all of it before it goes to main.

Sidenote: I also did a few minor style changes to fix things that were broken in previous merges...