### PR TITLE
Fix map onload center if coordinates exist + add new POI button

### DIFF
--- a/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/Default.cshtml
+++ b/LiveMapDashboard.Web/Views/Shared/Components/PoiForm/Default.cshtml
@@ -3,8 +3,7 @@
 
 <div class="max-w-10xl pt-2 px-4 sm:px-6 lg:px-6 lg:pt-2 mx-auto">
     <div class="flex justify-between">
-        <a href="javascript:history.back()"
-           class="bg-transparent hover:bg-transparent px-4 py-2 text-blue-500 hover:bg-blue-600">
+        <a asp-controller="Poi" asp-action="Index" class="bg-transparent hover:bg-transparent px-4 py-2 text-blue-500 hover:bg-blue-600">
             Go Back
         </a>
         <form method="delete" asp-controller="poi" asp-action="delete">

--- a/LiveMapDashboard.Web/Views/Shared/Components/PoiList/Default.cshtml
+++ b/LiveMapDashboard.Web/Views/Shared/Components/PoiList/Default.cshtml
@@ -1,5 +1,11 @@
 ﻿@model LiveMapDashboard.Web.Models.Poi.PoiListViewModel
 
+<div class="py-4 flex justify-end">
+    <a asp-controller="Poi" asp-action="PoiCreateForm" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">
+        New Point Of Interest
+    </a>
+</div>
+
 <div class="flex flex-col">
     <div class="-m-1.5 overflow-x-auto">
         <div class="p-1.5 min-w-full inline-block align-middle">

--- a/LiveMapDashboard.Web/wwwroot/js/park-place-markers-maplibre.js
+++ b/LiveMapDashboard.Web/wwwroot/js/park-place-markers-maplibre.js
@@ -101,7 +101,6 @@ function placeMarkerOnMap(){
     centerOnMap(); // Center the map on the new marker
 }
 
-
 document.getElementById('applyLocationButton').addEventListener('click', () => {
     if (!clickedLngLat) {
         showAlert('warning', 'Klik eerst op de kaart om een locatie te selecteren.');
@@ -113,4 +112,15 @@ document.getElementById('applyLocationButton').addEventListener('click', () => {
     showAlert('success', 'Coördinaten zijn toegepast.');
 });
 
+map.on('load', () => {
+    const long = parseFloat(document.getElementById('Coordinate_Longitude').value.replace(',', '.'))
+    const lat = parseFloat(document.getElementById('Coordinate_Latitude').value.replace(',', '.'))
 
+    if ((long && lat) && (long !== 0 && lat !== 0)) {
+        const clampedLong = Math.max(Math.min(long, 90), -90);
+        const clampedLat = Math.max(Math.min(lat, 90), -90);
+
+        clickedLngLat = {lng: clampedLong, lat: clampedLat};
+        placeMarkerOnMap();
+    }
+});


### PR DESCRIPTION
The map should now center if coordinates are already present. If you're wondering "why the clamp?" Some seeder objects have long's and lat's that exceed 90 or -90 which is not accepted, so to avoid console errors and broken maps we clamp it.