### PR TITLE
Add re-center button to the map based on the current set marker

### DIFF
--- a/LiveMapDashboard.Web/wwwroot/css/site.css
+++ b/LiveMapDashboard.Web/wwwroot/css/site.css
@@ -1,5 +1,5 @@
 /**
- * Custom code and changes
+ * Global styles
  */
 html {
   font-size: 14px;
@@ -50,4 +50,18 @@ body {
 
 .fade-out {
     opacity: 0;
+}
+
+/**
+ * Map styles
+ */
+@keyframes FailShake {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-3px); }
+    50% { transform: translateX(3px); }
+    75% { transform: translateX(-3px); }
+}
+
+.failShake {
+    animation: FailShake 0.3s ease-in-out;
 }

--- a/LiveMapDashboard.Web/wwwroot/js/map/map-factory.js
+++ b/LiveMapDashboard.Web/wwwroot/js/map/map-factory.js
@@ -40,6 +40,54 @@ const MapFactory = (() => {
     };
     
     function addBasicControls(map) {
+        class RecenterButton {
+            onAdd(map) {
+                this.map = map;
+                
+                const button = document.createElement('button');
+                button.className = 'maplibregl-ctrl-icon';
+                button.type = 'button';
+                button.title = 'Recenter map';
+
+                button.innerHTML = `
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                        width="20" height="20" fill="none" stroke="#333333"
+                        stroke-width="3" stroke-linecap="round" stroke-linejoin="round"
+                        style="display: block; margin: auto; vertical-align: middle;">
+                        <line x1="2" x2="5" y1="12" y2="12"/>
+                        <line x1="19" x2="22" y1="12" y2="12"/>
+                        <line x1="12" x2="12" y1="2" y2="5"/>
+                        <line x1="12" x2="12" y1="19" y2="22"/>
+                        <circle cx="12" cy="12" r="7"/>
+                        <circle cx="12" cy="12" r="3"/>
+                    </svg>
+                `;
+
+                button.addEventListener('click', () => {
+                    if (window.mapCenter) {
+                        const coordinates = window.mapCenter.getLngLat();
+                        map.flyTo({ center: [coordinates.lng, coordinates.lat], zoom: 15 });
+                    } else {
+                        button.classList.add('failShake');
+                        button.addEventListener('animationend', () => {
+                            button.classList.remove('failShake');
+                        }, { once: true });
+                    }
+                });
+
+                const container = document.createElement('div');
+                container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+                container.appendChild(button);
+
+                return container;
+            }
+
+            onRemove() {
+                this.map = undefined;
+            }
+        }
+        map.addControl(new RecenterButton(), 'top-right');
+
         map.addControl(new maplibregl.NavigationControl({
             visualizePitch: true,
             visualizeRoll: true,
@@ -47,6 +95,7 @@ const MapFactory = (() => {
             showCompass: true
         }));
         map.addControl(new maplibregl.FullscreenControl());
+
     }
 
     function addGeocoder(map) {

--- a/LiveMapDashboard.Web/wwwroot/js/map/park-boundaries-maplibre.js
+++ b/LiveMapDashboard.Web/wwwroot/js/map/park-boundaries-maplibre.js
@@ -101,7 +101,10 @@ function centerOnMap() {
     }
 
     const coordinates = features[0].geometry.coordinates[0];
-    map.setCenter(getCenterOfCoordinates(coordinates));
+    const center = getCenterOfCoordinates(coordinates);
+    
+    map.setCenter(center);
+    window.mapCenter = new maplibregl.Marker().setLngLat(center);
 }
 
 function getCenterOfCoordinates(coordinates) {
@@ -180,6 +183,7 @@ function saveMap() {
 
     // Save Map
     const coordinates = features[0].geometry.coordinates[0];
+    window.mapCenter = new maplibregl.Marker().setLngLat(coordinates);
 
     fetch(`${BACKEND_URL}${API_PATH}/${mapId}`, {
         method: "PATCH",

--- a/LiveMapDashboard.Web/wwwroot/js/map/park-place-markers-maplibre.js
+++ b/LiveMapDashboard.Web/wwwroot/js/map/park-place-markers-maplibre.js
@@ -86,6 +86,8 @@ function placeMarkerOnMap(){
         .setLngLat([clickedLngLat.lng, clickedLngLat.lat])
         .addTo(map);
 
+    window.mapCenter = marker;
+    
     // Store the marker in the markers array
     markers.push(marker);
     centerOnMap(); // Center the map on the new marker


### PR DESCRIPTION
So the search zooms out so that you can view all the locations in your field of view, but how do we get back to where we were? This is a valid feedback point and so this hotfix came to be. Its just a simple component that looks at the window for a set center to re-center on. I changed the 2 maps to set this value on save and load